### PR TITLE
feat: add roles slash command

### DIFF
--- a/src/commands/utility/roles.ts
+++ b/src/commands/utility/roles.ts
@@ -1,6 +1,7 @@
 import {
   ChatInputCommandInteraction,
   EmbedBuilder,
+  MessageFlags,
   SlashCommandBuilder,
 } from "discord.js";
 
@@ -14,7 +15,7 @@ export const command = {
     if (!interaction.guild) {
       await interaction.reply({
         content: "This command can only be used within a server.",
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       return;
     }

--- a/src/commands/utility/roles.ts
+++ b/src/commands/utility/roles.ts
@@ -1,0 +1,49 @@
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  SlashCommandBuilder,
+} from "discord.js";
+
+export const command = {
+  data: new SlashCommandBuilder()
+    .setName("roles")
+    .setDescription("Provides a list of roles for the server."),
+
+  async execute(interaction: ChatInputCommandInteraction) {
+    // Ensure the command is executed in a guild
+    if (!interaction.guild) {
+      await interaction.reply({
+        content: "This command can only be used within a server.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    // Get all roles (excluding the @everyone role)
+    const roles = interaction.guild.roles.cache
+      .filter((role) => role.id !== interaction.guild!.id)
+      // Optionally, sort roles by member count (descending)
+      .sort((a, b) => b.members.size - a.members.size);
+
+    // Build a display string for the embed.
+    const roleList = roles
+      .map((role) => {
+        const roleMention = `<@&${role.id}>`;
+        return `${roleMention} — Members: \`${role.members.size}\``;
+      })
+      .join("\n");
+
+    // Create an embed "card" with the list of roles.
+    const embed = new EmbedBuilder()
+      .setTitle("Server Roles")
+      .setDescription(roleList || "No roles found.")
+      .setColor(0x2f3136) // Neutral embed color; individual role colors will show in the mentions.
+      .setTimestamp();
+
+    // Reply with the embed and the interactive select menu
+    await interaction.reply({
+      embeds: [embed],
+      allowedMentions: { roles: [] }, // This prevents role pings
+    });
+  },
+};


### PR DESCRIPTION
[Related Issue #16 ](https://github.com/SourcewareLab/GlaDOS-bot/issues/16)
- Added a `roles` slash command
- New command displays all roles for a server in the roles color as a mention along with how many members are assigned to that role.
- Notifications to members of the role are disabled for this command.

Example:
![Glados_Bot_roles](https://github.com/user-attachments/assets/1242b3c6-a594-47d3-abb2-e250db937ef1)
