### PR TITLE
feat: Adding Heirarchy to each role based on permissions

### DIFF
--- a/src/commands/utility/roles.ts
+++ b/src/commands/utility/roles.ts
@@ -3,6 +3,8 @@ import {
   EmbedBuilder,
   MessageFlags,
   SlashCommandBuilder,
+  PermissionsBitField,
+  Role
 } from "discord.js";
 
 export const command = {
@@ -24,7 +26,7 @@ export const command = {
     const roles = interaction.guild.roles.cache
       .filter((role) => role.id !== interaction.guild!.id)
       // Optionally, sort roles by member count (descending)
-      .sort((a, b) => b.members.size - a.members.size);
+      .sort((a, b) => getHeirarchy(b) - getHeirarchy(a));
 
     // Build a display string for the embed.
     const roleList = roles
@@ -47,4 +49,15 @@ export const command = {
       allowedMentions: { roles: [] }, // This prevents role pings
     });
   },
+};
+
+function getHeirarchy(role: Role) {
+  if (role.permissions.has(PermissionsBitField.Flags.Administrator)) return 100;
+  if (role.permissions.has(PermissionsBitField.Flags.ManageGuild)) return 80;
+  if (role.permissions.has(PermissionsBitField.Flags.ManageRoles)) return 70;
+  if (role.permissions.has(PermissionsBitField.Flags.KickMembers)) return 60;
+  if (role.permissions.has(PermissionsBitField.Flags.BanMembers)) return 50;
+  if (role.permissions.has(PermissionsBitField.Flags.ModerateMembers)) return 40;
+  if (role.permissions.has(PermissionsBitField.Flags.ManageMessages)) return 30;
+  return 0; // Regular roles
 };


### PR DESCRIPTION
each role is given a Permission based ordering value and are then sorted to have higher permission roles first.